### PR TITLE
Revert "Default log collection false"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
             TONIC_DB_USERNAME: ${TONIC_DB_USERNAME}
             TONIC_DB_PASSWORD: ${TONIC_DB_PASSWORD}
             TONIC_DB_SSLMODE: ${TONIC_DB_SSLMODE:-require}
-            ENABLE_LOG_COLLECTION: ${ENABLE_LOG_COLLECTION:-false}
             # License should be configured by an admin within the Tonic UI. It can optionally be set here if there is no admin.
             # TONIC_LICENSE: ${TONIC_LICENSE}
             TONIC_STATISTICS_SEED: ${TONIC_STATISTICS_SEED}
@@ -61,7 +60,6 @@ services:
             TONIC_DB_USERNAME: ${TONIC_DB_USERNAME}
             TONIC_DB_PASSWORD: ${TONIC_DB_PASSWORD}
             TONIC_DB_SSLMODE: ${TONIC_DB_SSLMODE:-require}
-            ENABLE_LOG_COLLECTION: ${ENABLE_LOG_COLLECTION:-false}
             TONIC_STATISTICS_SEED: ${TONIC_STATISTICS_SEED}
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
             # should be the same as the tonic web server service name
@@ -91,7 +89,6 @@ services:
             - 7001:443
         environment:
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
-            ENABLE_LOG_COLLECTION: ${ENABLE_LOG_COLLECTION:-false}
             TONIC_DB_HOST: ${TONIC_DB_HOST}
             TONIC_DB_PORT: ${TONIC_DB_PORT}
             TONIC_DB_DATABASE: ${TONIC_DB_DATABASE}
@@ -129,7 +126,6 @@ services:
         mem_limit: 1024m
         environment:
             ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
-            ENABLE_LOG_COLLECTION: ${ENABLE_LOG_COLLECTION:-false}
         logging:
             driver: "json-file"
             options:
@@ -148,7 +144,6 @@ services:
     #     restart: unless-stopped
     #     mem_limit: 512m
     #     environment:
-    #         ENABLE_LOG_COLLECTION: ${ENABLE_LOG_COLLECTION:-false}
     #         ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
     #     volumes:
     #         - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Reverts swan-bitcoin/tonic_docker_compose#4 - log collection is not sent externally, stays on machine and is useful